### PR TITLE
Implement simple room pairing backend

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,15 +1,37 @@
 import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
+import { RoomManager } from './roomManager';
 
 const app = express();
+app.use(express.json());
 const httpServer = createServer(app);
 const io = new Server(httpServer);
 
 const PORT = 4000;
 
+const roomManager = new RoomManager();
+
 io.on('connection', (socket) => {
   console.log(`Client connected: ${socket.id}`);
+});
+
+app.post('/lobby/join', (req, res) => {
+  const { playerId } = req.body;
+  if (typeof playerId !== 'string') {
+    return res.status(400).json({ error: 'playerId required' });
+  }
+  roomManager.joinLobby(playerId);
+  res.json({ lobby: roomManager.getLobby() });
+});
+
+app.post('/pair', (_req, res) => {
+  roomManager.pairPlayers();
+  res.json({ rooms: roomManager.getRooms(), lobby: roomManager.getLobby() });
+});
+
+app.get('/lobby/count', (_req, res) => {
+  res.json({ count: roomManager.getLobby().length });
 });
 
 httpServer.listen(PORT, () => {

--- a/backend/src/roomManager.ts
+++ b/backend/src/roomManager.ts
@@ -1,0 +1,42 @@
+export interface Room {
+  id: string;
+  players: string[];
+}
+
+export class RoomManager {
+  private lobby: string[] = [];
+  private rooms: Room[] = [];
+  private counter = 1;
+
+  joinLobby(playerId: string) {
+    if (!this.lobby.includes(playerId)) {
+      this.lobby.push(playerId);
+    }
+  }
+
+  pairPlayers() {
+    while (this.lobby.length >= 2) {
+      const players = this.lobby.splice(0, 2);
+      const room: Room = { id: `room-${this.counter++}`, players };
+      this.rooms.push(room);
+    }
+  }
+
+  getRooms(): Room[] {
+    return this.rooms;
+  }
+
+  getLobby(): string[] {
+    return this.lobby;
+  }
+
+  removeFromLobby(playerId: string) {
+    this.lobby = this.lobby.filter((id) => id !== playerId);
+  }
+
+  clear() {
+    this.lobby = [];
+    this.rooms = [];
+    this.counter = 1;
+  }
+}

--- a/backend/test/roomManager.test.ts
+++ b/backend/test/roomManager.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RoomManager } from '../src/roomManager';
+
+describe('RoomManager pairing', () => {
+  let manager: RoomManager;
+
+  beforeEach(() => {
+    manager = new RoomManager();
+  });
+
+  it('creates a room when 2 players join', () => {
+    manager.joinLobby('p1');
+    manager.joinLobby('p2');
+    manager.pairPlayers();
+    expect(manager.getRooms().length).toBe(1);
+    expect(manager.getLobby().length).toBe(0);
+  });
+
+  it('creates two rooms when 4 players join', () => {
+    manager.joinLobby('p1');
+    manager.joinLobby('p2');
+    manager.joinLobby('p3');
+    manager.joinLobby('p4');
+    manager.pairPlayers();
+    expect(manager.getRooms().length).toBe(2);
+    expect(manager.getLobby().length).toBe(0);
+  });
+
+  it('leaves one player unmatched when number of players is odd', () => {
+    manager.joinLobby('p1');
+    manager.joinLobby('p2');
+    manager.joinLobby('p3');
+    manager.pairPlayers();
+    expect(manager.getRooms().length).toBe(1);
+    expect(manager.getLobby().length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `RoomManager` for pairing players into rooms of two
- add REST endpoints for joining lobby and pairing players
- add tests for room management

## Testing
- `npm --prefix backend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e4f188748333b820c4091cb2edee