### PR TITLE
Add room leaving and session timeouts

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,8 @@ const PORT = 4000;
 
 const roomManager = new RoomManager();
 
+setInterval(() => roomManager.cleanExpiredSessions(), 1000);
+
 io.on('connection', (socket) => {
   console.log(`Client connected: ${socket.id}`);
 });
@@ -30,8 +32,26 @@ app.post('/pair', (_req, res) => {
   res.json({ rooms: roomManager.getRooms(), lobby: roomManager.getLobby() });
 });
 
+app.post('/room/leave', (req, res) => {
+  const { playerId } = req.body;
+  if (typeof playerId !== 'string') {
+    return res.status(400).json({ error: 'playerId required' });
+  }
+  roomManager.leaveRoom(playerId);
+  res.json({ rooms: roomManager.getRooms(), lobby: roomManager.getLobby() });
+});
+
+app.post('/session/ping', (req, res) => {
+  const { playerId } = req.body;
+  if (typeof playerId !== 'string') {
+    return res.status(400).json({ error: 'playerId required' });
+  }
+  roomManager.ping(playerId);
+  res.json({ ok: true });
+});
+
 app.get('/lobby/count', (_req, res) => {
-  res.json({ count: roomManager.getLobby().length });
+  res.json({ count: roomManager.getLobbyCount() });
 });
 
 httpServer.listen(PORT, () => {

--- a/backend/src/roomManager.ts
+++ b/backend/src/roomManager.ts
@@ -6,15 +6,19 @@ export interface Room {
 export class RoomManager {
   private lobby: string[] = [];
   private rooms: Room[] = [];
+  private sessions: Record<string, number> = {};
   private counter = 1;
+  private readonly timeoutMs = 10000;
 
   joinLobby(playerId: string) {
+    this.updateSession(playerId);
     if (!this.lobby.includes(playerId)) {
       this.lobby.push(playerId);
     }
   }
 
   pairPlayers() {
+    this.cleanExpiredSessions();
     while (this.lobby.length >= 2) {
       const players = this.lobby.splice(0, 2);
       const room: Room = { id: `room-${this.counter++}`, players };
@@ -30,13 +34,52 @@ export class RoomManager {
     return this.lobby;
   }
 
+  getLobbyCount(): number {
+    return this.lobby.length;
+  }
+
+  ping(playerId: string) {
+    if (this.sessions[playerId]) {
+      this.sessions[playerId] = Date.now();
+    }
+  }
+
+  cleanExpiredSessions(now = Date.now()) {
+    for (const [id, last] of Object.entries(this.sessions)) {
+      if (now - last > this.timeoutMs) {
+        this.leaveRoom(id);
+      }
+    }
+  }
+
+  private updateSession(playerId: string) {
+    this.sessions[playerId] = Date.now();
+  }
+
   removeFromLobby(playerId: string) {
     this.lobby = this.lobby.filter((id) => id !== playerId);
+  }
+
+  leaveRoom(playerId: string) {
+    this.removeFromLobby(playerId);
+    this.rooms = this.rooms.filter((room) => {
+      if (room.players.includes(playerId)) {
+        room.players.forEach((p) => {
+          if (p !== playerId) {
+            this.joinLobby(p);
+          }
+        });
+        return false;
+      }
+      return true;
+    });
+    delete this.sessions[playerId];
   }
 
   clear() {
     this.lobby = [];
     this.rooms = [];
     this.counter = 1;
+    this.sessions = {};
   }
 }

--- a/backend/test/roomManager.test.ts
+++ b/backend/test/roomManager.test.ts
@@ -34,4 +34,37 @@ describe('RoomManager pairing', () => {
     expect(manager.getRooms().length).toBe(1);
     expect(manager.getLobby().length).toBe(1);
   });
+
+  it('removes player from lobby when they leave', () => {
+    manager.joinLobby('p1');
+    manager.leaveRoom('p1');
+    expect(manager.getLobbyCount()).toBe(0);
+  });
+
+  it('dissolves room when a player leaves', () => {
+    manager.joinLobby('p1');
+    manager.joinLobby('p2');
+    manager.pairPlayers();
+    manager.leaveRoom('p1');
+    expect(manager.getRooms().length).toBe(0);
+    expect(manager.getLobby()).toContain('p2');
+  });
+
+  it('removes expired player from lobby', () => {
+    manager.joinLobby('p1');
+    // simulate timeout
+    (manager as any).sessions['p1'] = Date.now() - 11000;
+    manager.cleanExpiredSessions();
+    expect(manager.getLobbyCount()).toBe(0);
+  });
+
+  it('dissolves room when a player session expires', () => {
+    manager.joinLobby('p1');
+    manager.joinLobby('p2');
+    manager.pairPlayers();
+    (manager as any).sessions['p1'] = Date.now() - 11000;
+    manager.cleanExpiredSessions();
+    expect(manager.getRooms().length).toBe(0);
+    expect(manager.getLobby()).toContain('p2');
+  });
 });


### PR DESCRIPTION
## Summary
- allow clients to leave rooms and ping the server
- automatically remove players if their session has been idle for 10s
- dissolve rooms when a player leaves or times out
- expose lobby count and add cleanup interval
- test leaving lobby/room and session timeout behaviour

## Testing
- `npx --prefix backend vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6841e703c7508333a577b93c98b086c8