### PR TITLE
Add frontend skeleton and API integration tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Lobby } from './components/Lobby'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div>
+      <h1>Multiplayer Pong</h1>
+      <Lobby />
+    </div>
   )
 }
 

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { joinLobby, pairPlayers, getLobbyCount, leaveRoom, connectToRoom } from './api'
+import { spawn } from 'child_process'
+import path from 'path'
+
+let proc: any
+
+const startServer = async () => {
+  const root = path.resolve(__dirname, '../..')
+  proc = spawn('npx', ['-y', 'ts-node', '--transpile-only', 'backend/src/index.ts'], { cwd: root })
+  await new Promise((r) => setTimeout(r, 1000))
+}
+
+const stopServer = () => proc && proc.kill()
+
+beforeEach(startServer)
+afterEach(stopServer)
+
+describe('api layer', () => {
+  it('can join lobby and get count', async () => {
+    await joinLobby('p1')
+    const count = await getLobbyCount()
+    expect(count).toBe(1)
+  })
+
+  it('can pair players', async () => {
+    await joinLobby('a')
+    await joinLobby('b')
+    const { rooms } = await pairPlayers()
+    expect(rooms.length).toBe(1)
+  })
+
+  it('can leave room', async () => {
+    await joinLobby('x')
+    await joinLobby('y')
+    await pairPlayers()
+    await leaveRoom('x')
+    const count = await getLobbyCount()
+    expect(count).toBe(2)
+  })
+})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,57 @@
+export interface Room {
+  id: string;
+  players: string[];
+}
+
+const BASE_URL = 'http://localhost:4000';
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(BASE_URL + path, options);
+  return res.json();
+}
+
+export async function joinLobby(playerId: string): Promise<string[]> {
+  const data = await request<{ lobby: string[] }>('/lobby/join', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ playerId }),
+  });
+  return data.lobby;
+}
+
+export async function pairPlayers(): Promise<{ rooms: Room[]; lobby: string[] }> {
+  return request('/pair', { method: 'POST' });
+}
+
+export async function leaveRoom(playerId: string): Promise<{ rooms: Room[]; lobby: string[] }> {
+  return request('/room/leave', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ playerId }),
+  });
+}
+
+export async function pingSession(playerId: string): Promise<void> {
+  await request('/session/ping', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ playerId }),
+  });
+}
+
+export async function getLobbyCount(): Promise<number> {
+  const data = await request<{ count: number }>('/lobby/count');
+  return data.count;
+}
+
+import { io, Socket } from 'socket.io-client';
+
+export function connectToRoom(roomId: string, playerId: string): Socket {
+  const socket = io(BASE_URL);
+  socket.emit('joinRoom', { roomId, playerId });
+  return socket;
+}
+
+export function sendMove(socket: Socket, x: number): void {
+  socket.emit('move', x);
+}

--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { connectToRoom, sendMove } from '../api'
+
+export function Game({ roomId, playerId }: { roomId: string; playerId: string }) {
+  const [state, setState] = useState<any>(null)
+
+  useEffect(() => {
+    const socket = connectToRoom(roomId, playerId)
+    socket.on('state', (s) => setState(s))
+    return () => {
+      socket.disconnect()
+    }
+  }, [roomId, playerId])
+
+  const move = (x: number) => {
+    const socket = connectToRoom(roomId, playerId)
+    sendMove(socket, x)
+  }
+
+  return (
+    <div>
+      <pre>{JSON.stringify(state)}</pre>
+      <button onClick={() => move(Math.random() * 100)}>Move</button>
+    </div>
+  )
+}

--- a/frontend/src/components/Lobby.tsx
+++ b/frontend/src/components/Lobby.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { getLobbyCount, joinLobby, pairPlayers } from '../api'
+
+export function Lobby() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      setCount(await getLobbyCount())
+    }
+    fetchCount()
+  }, [])
+
+  const handleJoin = async () => {
+    await joinLobby('player-' + Math.random())
+    setCount(await getLobbyCount())
+  }
+
+  const handlePair = async () => {
+    await pairPlayers()
+  }
+
+  return (
+    <div>
+      <p>Players waiting: {count}</p>
+      <button onClick={handleJoin}>Join Lobby</button>
+      <button onClick={handlePair}>Pair Players</button>
+    </div>
+  )
+}

--- a/frontend/src/components/RoomList.tsx
+++ b/frontend/src/components/RoomList.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import { pairPlayers } from '../api'
+
+export function RoomList() {
+  const [rooms, setRooms] = useState<any[]>([])
+
+  const pair = async () => {
+    const data = await pairPlayers()
+    setRooms(data.rooms)
+  }
+
+  return (
+    <div>
+      <button onClick={pair}>Refresh Rooms</button>
+      <pre>{JSON.stringify(rooms)}</pre>
+    </div>
+  )
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    threads: false
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold simple React components (Lobby, Game, RoomList)
- implement API helper for backend endpoints and socket connection
- add vitest config for node environment
- write integration tests spinning up backend and exercising API
- simplify App.tsx to use Lobby component

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6841f5d5e1048333a12ca7fff6d05ded