### PR TITLE
Add canvas gameplay rendering with automated tests

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -7,7 +7,11 @@ let proc: any
 
 const startServer = async () => {
   const root = path.resolve(__dirname, '../..')
-  proc = spawn('npx', ['-y', 'ts-node', '--transpile-only', 'backend/src/index.ts'], { cwd: root })
+  const tsNode = path.join(root, 'backend/node_modules/ts-node/dist/bin.js')
+  proc = spawn('node', [tsNode, '--transpile-only', 'src/index.ts'], {
+    cwd: path.join(root, 'backend'),
+    stdio: 'ignore',
+  })
   await new Promise((r) => setTimeout(r, 1000))
 }
 

--- a/frontend/src/components/Game.tsx
+++ b/frontend/src/components/Game.tsx
@@ -1,26 +1,43 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { connectToRoom, sendMove } from '../api'
+import type { GameState } from '../types'
+import { GameCanvas } from './GameCanvas'
+import type { Socket } from 'socket.io-client'
 
 export function Game({ roomId, playerId }: { roomId: string; playerId: string }) {
-  const [state, setState] = useState<any>(null)
+  const [state, setState] = useState<GameState | null>(null)
+  const socketRef = useRef<Socket | null>(null)
+  const mouseX = useRef(0)
+  const [winner, setWinner] = useState<string | null>(null)
 
   useEffect(() => {
     const socket = connectToRoom(roomId, playerId)
-    socket.on('state', (s) => setState(s))
+    socketRef.current = socket
+    socket.on('state', (s: GameState) => setState(s))
+    socket.on('gameOver', ({ winner }) => setWinner(winner))
     return () => {
       socket.disconnect()
+      socketRef.current = null
     }
   }, [roomId, playerId])
 
-  const move = (x: number) => {
-    const socket = connectToRoom(roomId, playerId)
-    sendMove(socket, x)
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (socketRef.current) {
+        sendMove(socketRef.current, mouseX.current)
+      }
+    }, 40)
+    return () => clearInterval(id)
+  }, [])
+
+  const onMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect()
+    mouseX.current = e.clientX - rect.left
   }
 
-  return (
-    <div>
-      <pre>{JSON.stringify(state)}</pre>
-      <button onClick={() => move(Math.random() * 100)}>Move</button>
-    </div>
-  )
+  if (winner) {
+    return <div>Winner: {winner}</div>
+  }
+
+  return <GameCanvas state={state} onMouseMove={onMouseMove} />
 }

--- a/frontend/src/components/GameCanvas.tsx
+++ b/frontend/src/components/GameCanvas.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react'
+import type { GameState } from '../types'
+
+interface Props {
+  state: GameState | null
+  width?: number
+  height?: number
+  onMouseMove?: (e: React.MouseEvent<HTMLCanvasElement>) => void
+}
+
+export function GameCanvas({ state, width = 100, height = 100, onMouseMove }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.fillStyle = 'black'
+    ctx.fillRect(0, 0, width, height)
+    if (!state) return
+    ctx.fillStyle = 'white'
+    const paddleWidth = 20
+    const paddleHeight = 4
+    ctx.fillRect(state.paddles.top.x - paddleWidth / 2, 0, paddleWidth, paddleHeight)
+    ctx.fillRect(
+      state.paddles.bottom.x - paddleWidth / 2,
+      height - paddleHeight,
+      paddleWidth,
+      paddleHeight
+    )
+    const radius = 3
+    ctx.beginPath()
+    ctx.arc(state.ball.x, state.ball.y, radius, 0, Math.PI * 2)
+    ctx.fill()
+  }, [state, width, height])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      onMouseMove={onMouseMove}
+      style={{ border: '1px solid white', touchAction: 'none' }}
+    />
+  )
+}

--- a/frontend/src/components/Lobby.tsx
+++ b/frontend/src/components/Lobby.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react'
 import { getLobbyCount, joinLobby, pairPlayers } from '../api'
+import { Game } from './Game'
 
 export function Lobby() {
   const [count, setCount] = useState(0)
+  const [playerId, setPlayerId] = useState<string | null>(null)
+  const [roomId, setRoomId] = useState<string | null>(null)
 
   useEffect(() => {
     const fetchCount = async () => {
@@ -12,12 +15,24 @@ export function Lobby() {
   }, [])
 
   const handleJoin = async () => {
-    await joinLobby('player-' + Math.random())
+    const id = 'player-' + Math.random().toString(36).slice(2, 8)
+    await joinLobby(id)
+    setPlayerId(id)
     setCount(await getLobbyCount())
   }
 
   const handlePair = async () => {
-    await pairPlayers()
+    const { rooms } = await pairPlayers()
+    if (playerId) {
+      const room = rooms.find((r) => r.players.includes(playerId))
+      if (room) {
+        setRoomId(room.id)
+      }
+    }
+  }
+
+  if (roomId && playerId) {
+    return <Game roomId={roomId} playerId={playerId} />
   }
 
   return (
@@ -25,6 +40,7 @@ export function Lobby() {
       <p>Players waiting: {count}</p>
       <button onClick={handleJoin}>Join Lobby</button>
       <button onClick={handlePair}>Pair Players</button>
+      {playerId && <p>Joined as {playerId}</p>}
     </div>
   )
 }

--- a/frontend/src/gameplay.test.ts
+++ b/frontend/src/gameplay.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'child_process'
+import path from 'path'
+import { io } from 'socket.io-client'
+import { joinLobby, pairPlayers } from './api'
+
+let proc: any
+const root = path.resolve(__dirname, '..', '..')
+
+const startServer = async () => {
+  const tsNode = path.join(root, 'backend/node_modules/ts-node/dist/bin.js')
+  proc = spawn('node', [tsNode, '--transpile-only', 'src/index.ts'], {
+    cwd: path.join(root, 'backend'),
+    stdio: 'ignore',
+  })
+  await new Promise((r) => setTimeout(r, 1000))
+}
+
+const stopServer = () => proc && proc.kill()
+
+beforeEach(startServer)
+afterEach(stopServer)
+
+describe('gameplay', () => {
+  it('clients receive game state', async () => {
+    await joinLobby('a')
+    await joinLobby('b')
+    const { rooms } = await pairPlayers()
+    const roomId = rooms[0].id
+
+    const s1 = io('http://localhost:4000')
+    const states: any[] = []
+    s1.emit('joinRoom', { roomId, playerId: 'a' })
+    s1.on('state', (s) => states.push(s))
+    const s2 = io('http://localhost:4000')
+    s2.emit('joinRoom', { roomId, playerId: 'b' })
+
+    await new Promise((r) => setTimeout(r, 500))
+    s1.disconnect()
+    s2.disconnect()
+
+    expect(states.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,21 @@
+export interface Paddle {
+  x: number;
+}
+
+export interface Ball {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+export interface Score {
+  top: number;
+  bottom: number;
+}
+
+export interface GameState {
+  ball: Ball;
+  paddles: { top: Paddle; bottom: Paddle };
+  score: Score;
+}


### PR DESCRIPTION
## Summary
- draw paddles and ball on a new `GameCanvas` component
- update `Game` to render canvas, send paddle moves every 40ms and handle game over
- let `Lobby` launch the game when paired
- provide shared game state types
- add gameplay integration test and fix API tests to spawn the backend correctly

## Testing
- `npx vitest run` in `frontend`
- `npx vitest run` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68420dd1a2f48333937341d5ed6eb22f