### PR TITLE
Fix tests by running sequentially

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "vitest",
+    "test": "vitest run",
     "dev": "ts-node-dev --respawn src/index.ts"
   },
   "keywords": [],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run src/api.test.ts && vitest run src/gameplay.test.ts && vitest run src/components/Game.test.tsx && vitest run src/components/ScoreBoard.test.tsx && vitest run src/utils/sum.test.ts"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    threads: false
+    threads: false,
+    sequence: {
+      concurrent: false
+    },
+    maxConcurrency: 1
   }
 })


### PR DESCRIPTION
## Summary
- ensure backend tests use `vitest run`
- avoid concurrency issues by running frontend tests sequentially
- configure vitest to limit concurrency

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68429cce0f548333912ab0b0df4a4841